### PR TITLE
support multiple report formats in one test run

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ $ automated-screenshot-diff compare -p v1 -c v2 -s screenshots/ -o html
 ```bash
 $ automated-screenshot-diff compare -p v1 -c v2 -s screenshots/ -o json
 ```
+#### To compare release v1 and v2, and saving the analysis as JSON and HTML.
+```bash
+$ automated-screenshot-diff compare -p v1 -c v2 -s screenshots/ -o json,html
 
 ## Demonstration
 ##### login_widget-v1.png

--- a/bin/automated-screenshot-diff
+++ b/bin/automated-screenshot-diff
@@ -7,6 +7,10 @@ var program = require('commander'),
 program
   .version(package.version)
 
+  function list(val) {
+      return val.split(',').map(String);
+  }
+
 program
   .command('compare')
   .description('command to compare screenshots')
@@ -14,7 +18,7 @@ program
   .option('-c --current-release [currentRelease]', 'Current release beeing compared.')
   .option('-s --source [source]', 'Where are your screenshots folder?')
   .option('-i --ignore-not-changed [ignoreNotChanged]', 'Should I ignore not changed scenarios?')
-  .option('-o --outputFormat [outputFormat]', 'HTML or JSON?')
+  .option('-o --outputFormat [outputFormat]', 'output formats as as list, default is html e.g. html,json', list, ['html'])
   .action(function(opts){
     new Screenshots().compare(opts);
   })

--- a/lib/screenshots.js
+++ b/lib/screenshots.js
@@ -95,10 +95,12 @@
       if (files.length === 0)
         return error("nothing to do here");
 
-      outputFormat = outputFormat.toLowerCase();
-      if (outputFormat === "json") {
+      outputFormat = outputFormat.map(function(item) { return item.toLowerCase() });
+
+      if (_.contains(outputFormat,"json")) {
         saveJSONFile(source + currentRelease + "-" + previousRelease + "-diff.json", files);
-      } else if (outputFormat === "html") {
+      }
+      if (_.contains(outputFormat,"html")) {
         var 
           htmlData = {
             files: _.filter(files, function (file) {


### PR DESCRIPTION
Hi,

Firstly my use case.  I always want the html diff report, however I want to run these tests from a framework and having the json report is also useful for machine parsing and exiting with the correct exit code.

Therefore I would like to have the option of both reports.

Commander doesn't seem to really support this notion, they do have an example using a <list> see here:

https://github.com/visionmedia/commander.js/blob/master/examples/defaults

However this feels a little clumsy as relies on the user passing args in the correct format e.g. `-o html,json` without spaces etc.

This approach accesses the rawArgs property...maybe not great but see what you think. I have ensured tests still pass.

Thanks,

Matt.
